### PR TITLE
Refactor: Enemy 버그 수정

### DIFF
--- a/Source/Pizza/Private/JYS/EnemyFreddy.cpp
+++ b/Source/Pizza/Private/JYS/EnemyFreddy.cpp
@@ -93,6 +93,7 @@ void AEnemyFreddy::AttemptSpawnCube()
 			if (FreddyMesh2->bHiddenInGame == false && HiddenTime >= 3)
 			{
 				JumpScareFreddy();
+				JumpScareFreddySound();
 			}
 			// Freddy¸¦ Â÷·Ê´ë·Î Visible
 			if (FreddyMesh0->bHiddenInGame)
@@ -157,7 +158,8 @@ void AEnemyFreddy::JumpScareFreddySound()
 void AEnemyFreddy::JumpScareFreddy()
 {
 	FVector CameraLoc = Player->GetCameraTransform().GetLocation();
-	CameraLoc.X += 100;
+	CameraLoc.Y -= 100;
+	CameraLoc.Z -= 60;
 	SetActorLocation(CameraLoc);
 
 	GetMesh()->SetHiddenInGame(false);

--- a/Source/Pizza/Public/JYS/EnemyBonnie.h
+++ b/Source/Pizza/Public/JYS/EnemyBonnie.h
@@ -86,6 +86,8 @@ private:
 
 	void JumpScareSound();
 
+	bool JumpScarConditions();
+
 	UPROPERTY(EditAnywhere)
 	class USoundBase* FootStepsSFX;
 
@@ -95,4 +97,15 @@ private:
 	class USoundBase* BreathSFX;
 
 	void BreathSound();
+
+	bool BreathSoundConditions();
+
+	// 사운드 재생 완료 콜백
+    UFUNCTION()
+    void OnBreathSoundFinished();
+
+	bool bIsBreathSoundPlaying;
+
+	FTimerHandle BreathTimerHandle;
+
 };


### PR DESCRIPTION
1. 프레디 점프스케어 소리 빠진거 수정
2. 보니 점프스케어 발동이 안돼서 조건 다시 재설정 후 수정
3. 보니 숨소리 수정, 꺼지는거 추가
4. 보니 후레시를 켜서 숨을 때, 이동을 시작할 때 State를 바꿈 bIsMoving을 활용해 이동하도록 수정
5. 보니, 프레디 점프스케어 위치 조정 카메라 Location에서 Y는 -= 100, Z는 -= 60